### PR TITLE
Fix update on different song in album

### DIFF
--- a/services/google/main.js
+++ b/services/google/main.js
@@ -86,6 +86,7 @@ if (config.serviceConfig.whichService == 'google') {
   });
 
   var oldID
+  var oldTitle
   var oldTot
   var oldState = false
 
@@ -164,13 +165,15 @@ if (config.serviceConfig.whichService == 'google') {
 
   if (!oldID) {
     oldID = musicContent.song.albumArt
+    oldTitle = musicContent.song.title
     oldTot = musicContent.time.total
     oldState = musicContent.playing
     console.log(`[${new Date().toLocaleTimeString()}]: Initialised Successfully.`);
     rpc.setActivity(activity);
   }
-  if (oldID !== musicContent.song.albumArt || oldTot !== musicContent.time.total || oldState !== musicContent.playing) {
+  if (oldID !== musicContent.song.albumArt || oldTitle !== musicContent.song.title || oldTot !== musicContent.time.total || oldState !== musicContent.playing) {
     oldID = musicContent.song.albumArt
+    oldTitle = musicContent.song.title
     oldTot = musicContent.time.total
     oldState = musicContent.playing
     console.log(`[${new Date().toLocaleTimeString()}]: Status Change Detected, updating Rich Presence.`)


### PR DESCRIPTION
Currently Google Play Music's Total and Current Time are slightly broken and won't always report back with the correct amount! [Issue from GPMDP Github](https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/issues/2630)

Because of this, in the If statement on line `174` it won't always trigger if someone is constantly listening through an album. The Album Art stays the same, Google caches the next song so it doesn't pause briefly between songs, and the total time doesn't change due to this bug!